### PR TITLE
Refs #103858; When using the global search from the header, don't display the expired results

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -3,6 +3,9 @@ Changelog
 
 24.0-dev0 - (unreleased)
 ---------------------
+* Bugfix: When using the global search from the header, don't display the
+  expired results
+  [szabozo0 refs #103858]
 
 23.9 - (2019-02-21)
 ---------------------

--- a/eea/design/skins/eeadesign_js/eea-custom-search.js
+++ b/eea/design/skins/eeadesign_js/eea-custom-search.js
@@ -66,11 +66,33 @@ EEA.CustomSearch = function (context) {
             },
             'must': {
               'bool': {
-                'must': [{
-                  'query_string': {
-                    'query': ""
+                'must': [
+                  {
+                    'query_string': {
+                      'query': ""
+                    }
+                  },
+
+                  {
+                   "constant_score":{
+                      "filter":{
+                         "bool":{
+                            "should":[
+                               {
+                                "bool":{
+                                   "must_not":{
+                                      "exists":{
+                                         "field":"expires"
+                                        }
+                                     }
+                                  }
+                               }
+                            ]
+                         }
+                      }
+                    }
                   }
-                }]
+                ]
               }
             }
           }


### PR DESCRIPTION
Refs #103858; When using the global search from the header, don't display the expired results